### PR TITLE
fix: support aa degrees for credential type

### DIFF
--- a/backend/data/program-credentials/merge-credentials.py
+++ b/backend/data/program-credentials/merge-credentials.py
@@ -6,6 +6,7 @@ Created on Thu Feb 18 13:59:05 2021
 """
 
 import pandas as pd
+from enum import Enum
 import sys
 
 def merge_lookup_label(result: pd.DataFrame, lookup_df: pd.DataFrame, column: str, lookup_id_column: str = "ID", lookup_label_column: str = "NAME"):
@@ -38,41 +39,124 @@ def clean_official_name(df: pd.DataFrame):
     df['OFFICIALNAME'] = df['OFFICIALNAME'].str.replace('AAS', 'A.A.S.')
     return df
 
+class CredentialType(Enum):
+    # http://credreg.net/ctdl/terms/credentialType#Certificate
+    # Credential that designates requisite knowledge and skills of an occupation, profession, or academic program.
+    Certificate = 'Certificate'
+    # http://credreg.net/ctdl/terms/credentialType#ApprenticeshipCertificate
+    # Credential earned through work-based learning and earn-and-learn models that meet standards and are applicable to industry trades and professions.
+    ApprenticeshipCertificate = 'Apprenticeship'
+    # http://credreg.net/ctdl/terms/credentialType#JourneymanCertificate
+    # Credential awarded to skilled workers on successful completion of an apprenticeship in industry trades and professions.
+    JourneymanCertificate = 'Journeyman Certificate'
+    # http://credreg.net/ctdl/terms/credentialType#MasterCertificate
+    # Credential awarded upon demonstration through apprenticeship of the highest level of skills and performance in industry trades and professions.
+    MasterCertificate = 'Master Certificate'
+
+    # http://credreg.net/ctdl/terms/credentialType#Degree
+    # Academic credential conferred upon completion of a program or course of study, typically over multiple years at a college or university.
+    Degree = 'Degree'
+    # http://credreg.net/ctdl/terms/credentialType#AssociateDegree
+    # College/university award for students typically completing the first one to two years of post secondary school education.
+    AssociateDegree = 'Associate Degree'
+    # http://credreg.net/ctdl/terms/credentialType#BachelorDegree
+    # College/university award for students typically completing three to five years of education where course work and activities advance skills beyond those of the first one to two years of college/university study.
+    BachelorDegree = 'Bachelor Degree'
+    # http://credreg.net/ctdl/terms/credentialType#MasterDegree
+    # Credential awarded for a graduate level course of study where course work and activities advance skills beyond those of the bachelor's degree or its equivalent.
+    MasterDegree = 'Masters Degree'
+    # http://credreg.net/ctdl/terms/credentialType#DoctoralDegree
+    # Highest credential award for students who have completed both a bachelor's degree and a master's degree or their equivalent as well as independent research and/or a significant project or paper.
+    DoctoralDegree = 'Doctoral Degree'
+    # http://credreg.net/ctdl/terms/credentialType#ProfessionalDoctorate
+    # Doctoral degree conferred upon completion of a program providing the knowledge and skills for the recognition, credential, or license required for professional practice.
+    ProfessionalDoctorate = 'Professional Doctorate'
+    # http://credreg.net/ctdl/terms/credentialType#ResearchDoctorate
+    # Doctoral degree conferred for advanced work beyond the master level, including the preparation and defense of a thesis or dissertation based on original research, or the planning and execution of an original project demonstrating substantial artistic or scholarly achievement.
+    ResearchDoctorate = 'Research Doctorate'
+    # http://credreg.net/ctdl/terms/credentialType#Badge
+    # Recognition designed to be displayed as a marker of accomplishment, activity, achievement, skill, interest, association, or identity.
+    Badge = 'Badge'
+    # http://credreg.net/ctdl/terms/credentialType#DigitalBadge
+    # Badge offered in digital form.
+    DigitalBadge = 'Digital Badge'
+    # http://credreg.net/ctdl/terms/credentialType#OpenBadge
+    # Visual symbol containing verifiable claims in accordance with the Open Badges specification and delivered digitally.
+    OpenBadge = 'Open Badge'
+
+    # http://credreg.net/ctdl/terms/credentialType#CertificateOfCompletion
+    # Credential that acknowledges completion of an assignment, training or other activity.
+    CertificateOfCompletion = 'Certificate of Completion'
+
+    # http://credreg.net/ctdl/terms/credentialType#Certification
+    # Time-limited, revocable, renewable credential awarded by an authoritative body for demonstrating the knowledge, skills, and abilities to perform specific tasks or an occupation.
+    Certification = 'Certification'
+
+    # http://credreg.net/ctdl/terms/credentialType#Diploma
+    # Credential awarded by educational institutions for successful completion of a course of study or its equivalent.
+    Diploma = 'Diploma'
+    # http://credreg.net/ctdl/terms/credentialType#GeneralEducationDevelopment
+    # Credential awarded by examination that demonstrates that an individual has acquired secondary school-level academic skills.
+    GeneralEducationDevelopment = 'General Education Diploma (GED)'
+    # http://credreg.net/ctdl/terms/credentialType#SecondarySchoolDiploma
+    # Diploma awarded by secondary education institutions for successful completion of a secondary school program of study.
+    SecondarySchoolDiploma = 'Secondary School Diploma'
+
+    # http://credreg.net/ctdl/terms/credentialType#License
+    # Credential awarded by a government agency or other authorized organization that constitutes legal authority to do a specific job and/or utilize a specific item, system or infrastructure and are typically earned through some combination of degree or certificate attainment, certifications, assessments, work experience, and/or fees, and are time-limited and must be renewed periodically.
+    License = 'License'
+
+    # http://credreg.net/ctdl/terms/credentialType#MicroCredential
+    # Credential that addresses a subset of field-specific knowledge, skills, or competencies; often developmental with relationships to other micro-credentials and field credentials.
+    MicroCredential = 'MicroCredential'
+
+    # http://credreg.net/ctdl/terms/credentialType#QualityAssuranceCredential
+    # Credential assuring that an organization, program, or awarded credential meets prescribed requirements and may include development and administration of qualifying examinations.
+    QualityAssuranceCredential = 'Quality Assurance Credential'
+
+    # TODO: How to handle ESL when it is not a type in CredentialEngine
+    ESL = 'ESL'
+    # TODO: How to handle PreApprenticeship when it is not a type in CredentialEngine
+    PreApprenticeship = 'Pre-Apprenticeship'
+
+    def __str__(self) -> str:
+        return str(self.value)
 
 def label_credential_type(row: pd.Series):
     # Certification
     official_name : str = row['OFFICIALNAME']
 
     if row['LEADTOLICENSE'] == "1" and row['LEADTOINDUSTRYCREDENTIAL'] == "0":
-        return 'License'
+        return CredentialType.License
 
     if 'M.' in official_name and 'Master' in row['DEGREEAWARDEDNAME']:
-        return 'Masters Degree'
+        return CredentialType.MasterDegree
 
-    if 'A.S.' in official_name:
-        return 'Associate Degree'
+    ASSOCIATE_NAME_TOKENS = { 'A.S.', 'A.A.', 'A.A.S'}
+    if any(map(official_name.__contains__, ASSOCIATE_NAME_TOKENS)) and ('A.S.E' not in official_name):
+        return CredentialType.AssociateDegree
 
     ESL_NAME_TOKENS = { 'ESL', 'English as a Second Language'}
     if any(map(official_name.__contains__, ESL_NAME_TOKENS)):
-        return 'ESL'
+        return CredentialType.ESL
 
     if 'High School Diploma - Adults' in official_name:
-        return 'Secondary School Diploma'
+        return CredentialType.SecondarySchoolDiploma
 
     if 'Apprentice' in official_name and 'Pre-Apprentice' not in official_name:
-        return 'Apprenticeship'
+        return CredentialType.ApprenticeshipCertificate
 
     if 'Pre-Apprentice' in official_name:
-        return 'Pre-Apprenticeship'
+        return CredentialType.PreApprenticeship
 
     GED_NAME_TOKENS = { 'GED', 'General Education Diploma', 'High School Equivalence', 'High School Equivalency'}
     if any(map(official_name.__contains__, GED_NAME_TOKENS)):
-        return 'General Education Diploma (GED)'
+        return CredentialType.GeneralEducationDevelopment
 
     if (row['LEADTOINDUSTRYCREDENTIAL'] == "1"):
-        return 'Certification'
+        return CredentialType.Certification
 
-    return 'Certificate of Completion'
+    return CredentialType.CertificateOfCompletion
 
 
 def export(df, yyyymmdd):


### PR DESCRIPTION
Summary
=======
1. Add missing support for A.A. degrees when searching official names
2. Refactor to use enum for labeling credential types

Test Plan
=========

Compared output for merged file to base branch output and confirmed only changes were inclusion of A.A. programs.

