### PR TITLE
feat: output esl and preapprenticeship as certificateofcompletion

### DIFF
--- a/backend/data/program-credentials/merge-credentials.py
+++ b/backend/data/program-credentials/merge-credentials.py
@@ -114,10 +114,12 @@ class CredentialType(Enum):
     # Credential assuring that an organization, program, or awarded credential meets prescribed requirements and may include development and administration of qualifying examinations.
     QualityAssuranceCredential = 'Quality Assurance Credential'
 
-    # TODO: How to handle ESL when it is not a type in CredentialEngine
-    ESL = 'ESL'
-    # TODO: How to handle PreApprenticeship when it is not a type in CredentialEngine
-    PreApprenticeship = 'Pre-Apprenticeship'
+    # We want to seperately detect ESL, but credential enginer does not currently support this type,
+    # until it does, we will treat it the same as CertificateOfCompletion in the output.
+    ESL = CertificateOfCompletion
+    # We want to seperately detect Pre-Apprenticeships, but credential enginer does not currently support this type,
+    # until it does, we will treat it the same as CertificateOfCompletion in the output.
+    PreApprenticeship = CertificateOfCompletion
 
     def __str__(self) -> str:
         return str(self.value)

--- a/backend/data/program-credentials/merge-credentials.py
+++ b/backend/data/program-credentials/merge-credentials.py
@@ -114,11 +114,13 @@ class CredentialType(Enum):
     # Credential assuring that an organization, program, or awarded credential meets prescribed requirements and may include development and administration of qualifying examinations.
     QualityAssuranceCredential = 'Quality Assurance Credential'
 
-    # We want to seperately detect ESL, but credential enginer does not currently support this type,
+    # We want to seperately detect ESL, but credential engine does not currently support this type,
     # until it does, we will treat it the same as CertificateOfCompletion in the output.
+    # Tracking need for this type in https://github.com/newjersey/d4ad/issues/401
     ESL = CertificateOfCompletion
-    # We want to seperately detect Pre-Apprenticeships, but credential enginer does not currently support this type,
+    # We want to seperately detect Pre-Apprenticeships, but credential engine does not currently support this type,
     # until it does, we will treat it the same as CertificateOfCompletion in the output.
+    # Tracking need for this type in https://github.com/newjersey/d4ad/issues/401
     PreApprenticeship = CertificateOfCompletion
 
     def __str__(self) -> str:


### PR DESCRIPTION
Summary
=========
Until credential engine supports these additional credential types
we are going to treat them as certificates of completion when
labeling the credential engine type.

Test Plan
=========
Compared the changed output for the merge file to see that ESL and Pre-Apprenticeship labels have changed to Certificate of Completion labels.
