### PR TITLE
refactor: enable using provider info for credential type labeling

### DIFF
--- a/backend/data/program-credentials/merge-credentials.py
+++ b/backend/data/program-credentials/merge-credentials.py
@@ -198,6 +198,7 @@ def main():
         'ID': "str", # match type for LICENSEAWARDED
         'Name': "str"
     })
+    providers_df = pd.read_csv(f"../providers_{yyyymmdd}.csv").add_prefix("PROVIDERS_")
 
     # Remove private data from programs file
     programs_df.drop(['SUBMITTERNAME', 'SUBMITTERTITLE'], axis=1, inplace=True)
@@ -213,8 +214,11 @@ def main():
 
     # Clean up Official Name
     programs_df = programs_df.pipe(clean_official_name)
+
+    # merge providers information for use in credential type labeling
+    merged_programs_providers = programs_df.merge(providers_df, how='left', left_on='PROVIDERID', right_on='PROVIDERS_PROVIDERID')
     # add Credential Types
-    programs_df['CREDENTIALTYPE'] = programs_df.apply(label_credential_type, axis=1)
+    programs_df['CREDENTIALTYPE'] = merged_programs_providers.apply(label_credential_type, axis=1)
     # export to csv
     export(programs_df, yyyymmdd)
 


### PR DESCRIPTION
Summary
========

As prework for a followup PR, this brings in the provider information into the dataframe used for doing credential type labeling.

As of right now, this should not change any of the output, and I wanted to do this as it's own PR to prove that it doesn't alter output. But a later followup PR will start using this provider infromation as part of the criteria for labeling some credential types (namely, degree credential types).

Test Plan
=========

Ran the etpl_table_seed_guide steps up through the merge-credentials script step for both the base commit and this branch and confirmed that there is no change to output.
