### PR TITLE
feat: match degree by degree awarded

### DIFF
--- a/backend/data/program-credentials/merge-credentials.py
+++ b/backend/data/program-credentials/merge-credentials.py
@@ -126,6 +126,17 @@ class CredentialType(Enum):
     def __str__(self) -> str:
         return str(self.value)
 
+
+# Lookup dictionary mapping a subset of IDs from the degree lookup table that map to
+# specific Credential Types in Credential Engine.
+DEGREE_AWARDED_TO_CREDENTIAL_TYPE : dict[str, CredentialType]= {
+    "200": CredentialType.AssociateDegree,
+    "300": CredentialType.BachelorDegree,
+    "500": CredentialType.MasterDegree,
+    "700": CredentialType.DoctoralDegree,
+}
+
+
 def label_credential_type(row: pd.Series):
     # Certification
     official_name : str = row['OFFICIALNAME']
@@ -166,21 +177,10 @@ def label_credential_type(row: pd.Series):
     # providers with other TYPEIDs where false postitives for degree credential types
     TYPEIDS_FOR_DEGREE_GRANTING_PROVIDERS = { "3", "4" }
 
-    # Label Associate Degree awarded from degree granting provider
-    if row['DEGREEAWARDED'] == "200" and row['PROVIDERS_TYPEID'] in TYPEIDS_FOR_DEGREE_GRANTING_PROVIDERS:
-        return CredentialType.AssociateDegree
-
-    # Label Bachelor Degree awarded from degree granting provider
-    if row['DEGREEAWARDED'] == "300" and row['PROVIDERS_TYPEID'] in TYPEIDS_FOR_DEGREE_GRANTING_PROVIDERS:
-        return CredentialType.BachelorDegree
-
-    # Label Master Degree awarded from degree granting provider
-    if row['DEGREEAWARDED'] == "500" and row['PROVIDERS_TYPEID'] in TYPEIDS_FOR_DEGREE_GRANTING_PROVIDERS:
-        return CredentialType.MasterDegree
-
-    # Label Doctoral Degree awarded from degree granting provider
-    if row['DEGREEAWARDED'] == "700" and row['PROVIDERS_TYPEID'] in TYPEIDS_FOR_DEGREE_GRANTING_PROVIDERS:
-        return CredentialType.DoctoralDegree
+    # Label academic degrees awarded from degree granting providers
+    degree_awarded_id = row['DEGREEAWARDED']
+    if DEGREE_AWARDED_TO_CREDENTIAL_TYPE.get(degree_awarded_id) and row['PROVIDERS_TYPEID'] in TYPEIDS_FOR_DEGREE_GRANTING_PROVIDERS:
+        return DEGREE_AWARDED_TO_CREDENTIAL_TYPE[degree_awarded_id]
 
     return CredentialType.CertificateOfCompletion
 

--- a/backend/data/program-credentials/merge-credentials.py
+++ b/backend/data/program-credentials/merge-credentials.py
@@ -160,6 +160,28 @@ def label_credential_type(row: pd.Series):
     if (row['LEADTOINDUSTRYCREDENTIAL'] == "1"):
         return CredentialType.Certification
 
+    # TODO: Track Down Lookup Values for Provider TYPEIDs.
+    # However, data analysis of our current dataset showed looking at the degree awarded field
+    # for providers with these TYPEIDs where true postitives for that credential type while
+    # providers with other TYPEIDs where false postitives for degree credential types
+    TYPEIDS_FOR_DEGREE_GRANTING_PROVIDERS = { "3", "4" }
+
+    # Label Associate Degree awarded from degree granting provider
+    if row['DEGREEAWARDED'] == "200" and row['PROVIDERS_TYPEID'] in TYPEIDS_FOR_DEGREE_GRANTING_PROVIDERS:
+        return CredentialType.AssociateDegree
+
+    # Label Bachelor Degree awarded from degree granting provider
+    if row['DEGREEAWARDED'] == "300" and row['PROVIDERS_TYPEID'] in TYPEIDS_FOR_DEGREE_GRANTING_PROVIDERS:
+        return CredentialType.BachelorDegree
+
+    # Label Master Degree awarded from degree granting provider
+    if row['DEGREEAWARDED'] == "500" and row['PROVIDERS_TYPEID'] in TYPEIDS_FOR_DEGREE_GRANTING_PROVIDERS:
+        return CredentialType.MasterDegree
+
+    # Label Doctoral Degree awarded from degree granting provider
+    if row['DEGREEAWARDED'] == "700" and row['PROVIDERS_TYPEID'] in TYPEIDS_FOR_DEGREE_GRANTING_PROVIDERS:
+        return CredentialType.DoctoralDegree
+
     return CredentialType.CertificateOfCompletion
 
 
@@ -198,7 +220,9 @@ def main():
         'ID': "str", # match type for LICENSEAWARDED
         'Name': "str"
     })
-    providers_df = pd.read_csv(f"../providers_{yyyymmdd}.csv").add_prefix("PROVIDERS_")
+    providers_df = pd.read_csv(f"../providers_{yyyymmdd}.csv", dtype={
+        "TYPEID": "str"
+    }).add_prefix("PROVIDERS_")
 
     # Remove private data from programs file
     programs_df.drop(['SUBMITTERNAME', 'SUBMITTERTITLE'], axis=1, inplace=True)

--- a/backend/data/program-credentials/merge-credentials.py
+++ b/backend/data/program-credentials/merge-credentials.py
@@ -172,6 +172,7 @@ def label_credential_type(row: pd.Series):
         return CredentialType.Certification
 
     # TODO: Track Down Lookup Values for Provider TYPEIDs.
+    # https://github.com/newjersey/d4ad/issues/411
     # However, data analysis of our current dataset showed looking at the degree awarded field
     # for providers with these TYPEIDs where true postitives for that credential type while
     # providers with other TYPEIDs where false postitives for degree credential types


### PR DESCRIPTION
Summary
=======

By combining both the degree awarded information along with the provider typeid, we can capture more of the Degree credentials without additional false postives, based on some data analysis of the current dataset.

When looking at the existing dataset, if the degree awarded indicated a specific degree type (Assocaite, Bachelor, Master, Doctoral) AND the TYPEID for the provider was either a 3 or a 4, the program appeared to be a program for that degree type. But if the TYPEID was anything else, then the program did not appear to be a degree program itself.

Test Plan
========

Ran this new version of merge-credentials and compared the output with prior runs. I looked at a sample of the changed program lines and confirmed that those programs were indeed being changed to the correct credential type.

