### PR TITLE
feat: run ci builds on branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,10 +74,7 @@ jobs:
 workflows:
   build-test-deploy:
     jobs:
-      - build-and-test:
-          filters:
-            branches:
-              only: master
+      - build-and-test
       - deploy:
           requires:
             - build-and-test


### PR DESCRIPTION
Summary
========

To support PR workflows and test incoming dependabot changes, we can configure CircleCI to run just the build and test part of the workflow on branches, leaving the deploys to only run off of main.

Test Plan
=======

This branch / PR serves as its own test as it should have a passing build and test status check from Circle CI