### PR TITLE
chore: update @types/node to match node major version 16

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       prefix: "chore"
       include: "scope"
     open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "npm"
     directory: "/backend"
     schedule:
@@ -21,3 +24,6 @@ updates:
       prefix: "chore"
       include: "scope"
     open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -25,9 +25,9 @@
       "devDependencies": {
         "@types/axios": "^0.14.0",
         "@types/cors": "^2.8.7",
-        "@types/express": "^4.17.6",
+        "@types/express": "^4.17.13",
         "@types/jest": "^27.4.1",
-        "@types/node": "^14.0.9",
+        "@types/node": "^16.11.56",
         "@types/pg": "^8.6.5",
         "@types/supertest": "^2.0.9",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
@@ -1605,21 +1605,21 @@
       "dev": true
     },
     "node_modules/@types/express": {
-      "version": "4.17.6",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
-      "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
       "dev": true,
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
+        "@types/express-serve-static-core": "^4.17.18",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.7",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.7.tgz",
-      "integrity": "sha512-EMgTj/DF9qpgLXyc+Btimg+XoH7A2liE8uKul8qSmMTHCeNYzydDKFdsJskDvw42UsesCnhO63dO0Grbj8J4Dw==",
+      "version": "4.17.30",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
+      "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -1818,9 +1818,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.0.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.9.tgz",
-      "integrity": "sha512-0sCTiXKXELOBxvZLN4krQ0FPOAA7ij+6WwvD0k/PHd9/KAkr4dXel5J9fh6F4x1FwAQILqAWkmpeuS6mjf1iKA==",
+      "version": "16.11.56",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.56.tgz",
+      "integrity": "sha512-aFcUkv7EddxxOa/9f74DINReQ/celqH8DiB3fRYgVDM2Xm5QJL8sl80QKuAnGvwAsMn+H3IFA6WCrQh1CY7m1A==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -1859,13 +1859,13 @@
       "dev": true
     },
     "node_modules/@types/serve-static": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.4.tgz",
-      "integrity": "sha512-jTDt0o/YbpNwZbQmE/+2e+lfjJEJJR0I3OFaKQKPWkASkCoW3i6fsUnqudSMcNAfbtmADGu8f4MV4q+GqULmug==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
       "dev": true,
       "dependencies": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
+        "@types/mime": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -13044,21 +13044,21 @@
       "dev": true
     },
     "@types/express": {
-      "version": "4.17.6",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
-      "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
+        "@types/express-serve-static-core": "^4.17.18",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.7",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.7.tgz",
-      "integrity": "sha512-EMgTj/DF9qpgLXyc+Btimg+XoH7A2liE8uKul8qSmMTHCeNYzydDKFdsJskDvw42UsesCnhO63dO0Grbj8J4Dw==",
+      "version": "4.17.30",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
+      "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -13219,9 +13219,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.9.tgz",
-      "integrity": "sha512-0sCTiXKXELOBxvZLN4krQ0FPOAA7ij+6WwvD0k/PHd9/KAkr4dXel5J9fh6F4x1FwAQILqAWkmpeuS6mjf1iKA==",
+      "version": "16.11.56",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.56.tgz",
+      "integrity": "sha512-aFcUkv7EddxxOa/9f74DINReQ/celqH8DiB3fRYgVDM2Xm5QJL8sl80QKuAnGvwAsMn+H3IFA6WCrQh1CY7m1A==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -13260,13 +13260,13 @@
       "dev": true
     },
     "@types/serve-static": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.4.tgz",
-      "integrity": "sha512-jTDt0o/YbpNwZbQmE/+2e+lfjJEJJR0I3OFaKQKPWkASkCoW3i6fsUnqudSMcNAfbtmADGu8f4MV4q+GqULmug==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
+        "@types/mime": "*",
+        "@types/node": "*"
       }
     },
     "@types/stack-utils": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -44,9 +44,9 @@
   "devDependencies": {
     "@types/axios": "^0.14.0",
     "@types/cors": "^2.8.7",
-    "@types/express": "^4.17.6",
+    "@types/express": "^4.17.13",
     "@types/jest": "^27.4.1",
-    "@types/node": "^14.0.9",
+    "@types/node": "^16.11.56",
     "@types/pg": "^8.6.5",
     "@types/supertest": "^2.0.9",
     "@typescript-eslint/eslint-plugin": "^5.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,6 @@
         "@testing-library/react": "^12.1.5",
         "@types/accounting": "^0.4.2",
         "@types/jest": "^29.0.0",
-        "@types/node": "^12.20.15",
         "@types/react": "^16.14.31",
         "@types/react-dom": "^16.9.16",
         "accounting": "^0.4.1",
@@ -33,6 +32,7 @@
         "typescript": "^4.7.4"
       },
       "devDependencies": {
+        "@types/node": "^16.11.56",
         "@types/reach__router": "^1.3.10",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
@@ -3981,9 +3981,9 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
     },
     "node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
+      "version": "16.11.56",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.56.tgz",
+      "integrity": "sha512-aFcUkv7EddxxOa/9f74DINReQ/celqH8DiB3fRYgVDM2Xm5QJL8sl80QKuAnGvwAsMn+H3IFA6WCrQh1CY7m1A=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -28653,9 +28653,9 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
     },
     "@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
+      "version": "16.11.56",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.56.tgz",
+      "integrity": "sha512-aFcUkv7EddxxOa/9f74DINReQ/celqH8DiB3fRYgVDM2Xm5QJL8sl80QKuAnGvwAsMn+H3IFA6WCrQh1CY7m1A=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,6 @@
     "@testing-library/react": "^12.1.5",
     "@types/accounting": "^0.4.2",
     "@types/jest": "^29.0.0",
-    "@types/node": "^12.20.15",
     "@types/react": "^16.14.31",
     "@types/react-dom": "^16.9.16",
     "accounting": "^0.4.1",
@@ -60,6 +59,7 @@
   },
   "proxy": "http://localhost:8080",
   "devDependencies": {
+    "@types/node": "^16.11.56",
     "@types/reach__router": "^1.3.10",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",


### PR DESCRIPTION
Summary
=========
- Updates the @types/node package to match the current node major
  version (16)
- Update @types/express to fix type issue with @types/node
- configures dependabot to not update major version of @types/nodes as
  we want this to match the node version.
  
 Test Plan
 =======
 - CI run passing, these are type information updates only and only impacts typescript compilation steps