### PR TITLE
feat: provide modified file for data migration without inner record line feeds

### DIFF
--- a/backend/data/transform-for-migration.py
+++ b/backend/data/transform-for-migration.py
@@ -5,7 +5,7 @@ def main():
     if any([df[col].str.contains('<LF>').any() for col in df.columns]):
         raise 'File contains LineFeed replacement token. We need to coordinate a new replacement token'
     df = df.replace('\n', '<LF>', regex=True)
-    df.to_csv('standardized_etpl_for_data_migration.csv', index=False, encoding='utf-8-sig')
+    df.to_csv('standardized_etpl_for_data_migration.csv', index=False, encoding='utf-8-sig', line_terminator='\r\n')
 
 
 if __name__ == '__main__':

--- a/backend/data/transform-for-migration.py
+++ b/backend/data/transform-for-migration.py
@@ -1,0 +1,12 @@
+import pandas as pd
+
+def main():
+    df = pd.read_csv('standardized_etpl.csv', dtype=str)
+    if any([df[col].str.contains('<LF>').any() for col in df.columns]):
+        raise 'File contains LineFeed replacement token. We need to coordinate a new replacement token'
+    df = df.replace('\n', '<LF>', regex=True)
+    df.to_csv('standardized_etpl_for_data_migration.csv', index=False, encoding='utf-8-sig')
+
+
+if __name__ == '__main__':
+    main()

--- a/etpl_table_seed_guide.md
+++ b/etpl_table_seed_guide.md
@@ -54,6 +54,12 @@ mv standardized_etpl.csv standardized_etpl_old.csv
 ./run-standardization.sh
 ```
 
+  6.1 To support the data migration to Credential Engine, we also need to create a modified form of `standardized_etpl.csv` that does not contain linefeed characters within the rows of the CSV file (This is a limitation in the import process to the system consumming this content for the data migration). To support this, we run an additional script to create `standardized_etpl_for_data_migration.csv`
+
+```shell script
+python3 transform-for-migration.py
+```
+
 ## Create migrations to update Postgres DB
 
 To learn more about database migrations and seed updates, see the README.


### PR DESCRIPTION
Summary
=======

The system importing the etpl data for migration into Credential Engine cannot support importing csv files with linefeeds within the individual record columns. They have asked us to replace the internal linefeed characters with the token `<LF>` and then they will replace this after the import back with the line feeds.

Test Plan
========

- Did a spot check on the file to ensure that the line feeds were replaced with `<LF>` instead.
