### PR TITLE
chore(deps-dev): bump wiremock from 2.27.1 to 2.33.2 in /backend

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -42,7 +42,7 @@
         "ts-jest": "^26.1.0",
         "ts-node": "^10.7.0",
         "tsconfig-paths": "^4.0.0",
-        "wiremock": "^2.27.1"
+        "wiremock": "^2.33.2"
       },
       "engines": {
         "node": "^16.0.0"
@@ -9504,6 +9504,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npm-java-runner": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/npm-java-runner/-/npm-java-runner-1.0.2.tgz",
+      "integrity": "sha512-rbf77NAjOm9O1N/IOytA2sabV5uER03fnvNJVwSkQdqwhqsVM4E69Jchg8AdfoYatMY2GR/TmB5KXJY9G8LRYA==",
+      "dev": true
+    },
     "node_modules/npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -10392,18 +10398,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -11019,33 +11013,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/shelljs": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "iojs": "*",
-        "node": ">=0.11.0"
-      }
-    },
-    "node_modules/shelljs/node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/shellwords": {
@@ -12740,15 +12707,15 @@
       }
     },
     "node_modules/wiremock": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/wiremock/-/wiremock-2.27.1.tgz",
-      "integrity": "sha512-UUQhhW2LpFIETo4mg0HW6wV0K6ewTXN74E/2T1tDqozL/rZouAQQ7qWOG2N9E0ai+3AWgJujaCNlgTV7LrJmzg==",
+      "version": "2.33.2",
+      "resolved": "https://registry.npmjs.org/wiremock/-/wiremock-2.33.2.tgz",
+      "integrity": "sha512-6nwyIC2VIQXtALr3oc9HA1P2OPcO8VeSY2nIPUzQ1n3Z8xOEgI3v9HE9Jmq77Ufemf5U1MY07BPmJDHu1J3NlQ==",
       "dev": true,
       "dependencies": {
-        "shelljs": "^0.7.5"
+        "npm-java-runner": "^0.0.17"
       },
       "bin": {
-        "wiremock": "jdeploy-bundle/jdeploy.js"
+        "wiremock": "index.js"
       }
     },
     "node_modules/word-wrap": {
@@ -20235,6 +20202,12 @@
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "dev": true
     },
+    "npm-java-runner": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/npm-java-runner/-/npm-java-runner-1.0.2.tgz",
+      "integrity": "sha512-rbf77NAjOm9O1N/IOytA2sabV5uER03fnvNJVwSkQdqwhqsVM4E69Jchg8AdfoYatMY2GR/TmB5KXJY9G8LRYA==",
+      "dev": true
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -20888,15 +20861,6 @@
         "picomatch": "^2.2.1"
       }
     },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.1.6"
-      }
-    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -21371,25 +21335,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
-    },
-    "shelljs": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "dependencies": {
-        "interpret": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-          "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-          "dev": true
-        }
-      }
     },
     "shellwords": {
       "version": "0.1.1",
@@ -22713,12 +22658,12 @@
       }
     },
     "wiremock": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/wiremock/-/wiremock-2.27.1.tgz",
-      "integrity": "sha512-UUQhhW2LpFIETo4mg0HW6wV0K6ewTXN74E/2T1tDqozL/rZouAQQ7qWOG2N9E0ai+3AWgJujaCNlgTV7LrJmzg==",
+      "version": "2.33.2",
+      "resolved": "https://registry.npmjs.org/wiremock/-/wiremock-2.33.2.tgz",
+      "integrity": "sha512-6nwyIC2VIQXtALr3oc9HA1P2OPcO8VeSY2nIPUzQ1n3Z8xOEgI3v9HE9Jmq77Ufemf5U1MY07BPmJDHu1J3NlQ==",
       "dev": true,
       "requires": {
-        "shelljs": "^0.7.5"
+        "npm-java-runner": "^1.0.2"
       }
     },
     "word-wrap": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -61,9 +61,12 @@
     "ts-jest": "^26.1.0",
     "ts-node": "^10.7.0",
     "tsconfig-paths": "^4.0.0",
-    "wiremock": "^2.27.1"
+    "wiremock": "^2.33.2"
   },
   "engines": {
     "node": "^16.0.0"
+  },
+  "overrides": {
+    "npm-java-runner": "^1.0.2"
   }
 }


### PR DESCRIPTION
Summary
=======


Replaces the dependabot PR for upgrading wiremock, with an overrides version added for a dependency of wiremock. 

Short of it is that the sub dependency `npm-java-runner` had been pulling in a `path` npm package that was causing issues with `good-fences`. That was fixed in a PR I made to npm-java-runner and has been released, but until there is a new release of the main wiremock service, the node wrapper for it won't have a release that pulls in the latest npm-java-runner version. The `overrides` works around that by forcing version resolution to the latest line of npm-java-runner.

See https://github.com/tomasbjerre/npm-java-runner/issues/1 for more background on the good-fences and npm-java-runner issue.

Test
======

Feature tests pass in CI.