### PR TITLE
chore(deps-dev): block accidental use of yarn

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,7 +75,8 @@
     "react-to-print": "^2.14.7"
   },
   "engines": {
-    "node": "^16.0.0",
+    "node": "^16.17.0",
+    "npm": "^8.15.0",
     "yarn": "please-use-npm"
   },
   "napa": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,7 +75,8 @@
     "react-to-print": "^2.14.7"
   },
   "engines": {
-    "node": "^16.0.0"
+    "node": "^16.0.0",
+    "yarn": "please-use-npm"
   },
   "napa": {
     "njwds": "newjersey/njwds#gh-pages"


### PR DESCRIPTION
# Summary

Simple "hack" to prevent accidental `yarn install`. Engine Yarn will not be able to find the Yarn version number `please-use-npm` and will halt the installation.

Prevents developers with `yarn` muscle memory from making a mess of the project.

_We could also further strengthen versions by specifying npm. But npm crossed a major version release with a minor Node release (Node 16.0.0 ships with npm 7.10.0, Node 16.11.0 shipped with npm 8.0.0)._

# Test

Will fail on `yarn` / `yarn install`.