### PR TITLE
chore(deps): bump typescript from 4.7.4 to 4.8.2

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,7 +20,7 @@
         "papaparse": "^5.2.0",
         "pg": "^8.2.1",
         "tslib": "^2.0.0",
-        "typescript": "^4.6.3"
+        "typescript": "^4.8.2"
       },
       "devDependencies": {
         "@types/axios": "^0.14.0",
@@ -12325,9 +12325,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22343,9 +22343,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw=="
     },
     "undefsafe": {
       "version": "2.0.5",

--- a/backend/package.json
+++ b/backend/package.json
@@ -39,7 +39,7 @@
     "papaparse": "^5.2.0",
     "pg": "^8.2.1",
     "tslib": "^2.0.0",
-    "typescript": "^4.6.3"
+    "typescript": "^4.8.2"
   },
   "devDependencies": {
     "@types/axios": "^0.14.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,7 @@
         "react-i18next": "^11.18.4",
         "react-scripts": "^4.0.3",
         "sass": "^1.54.8",
-        "typescript": "^4.7.4"
+        "typescript": "^4.8.2"
       },
       "devDependencies": {
         "@types/node": "^16.11.56",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "react-i18next": "^11.18.4",
     "react-scripts": "^4.0.3",
     "sass": "^1.54.8",
-    "typescript": "^4.7.4"
+    "typescript": "^4.8.2"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Summary
=======

Resolves the dependabot PR and ensures that both the frontend and backend are on the same typescript version.

Test Plan
=======

CI Passes.