### PR TITLE
chore(dev-deps): revert node version in Engines to 16.0.0 and remove npm version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,8 +75,7 @@
     "react-to-print": "^2.14.7"
   },
   "engines": {
-    "node": "^16.17.0",
-    "npm": "^8.15.0",
+    "node": "^16.0.0",
     "yarn": "please-use-npm"
   },
   "napa": {


### PR DESCRIPTION
# Summary

Revert Node version to ^16.0.0.

# Test Plan

CI Passes.
