### PR TITLE
fix: first single quote escape for fixtured data

### DIFF
--- a/backend/data/csvInserter.js
+++ b/backend/data/csvInserter.js
@@ -18,8 +18,7 @@ fs.readFile( path.join(__dirname,  csvFilename), function (err, fileContents) {
 
   let output = '';
 
-  fileContents = fileContents.toString().replace(`'`, `"`);
-  const data = Papa.parse(fileContents, { header: true }).data;
+  const data = Papa.parse(fileContents.toString(), { header: true }).data;
 
   const columns = Object.keys(data[0]).join(',');
 

--- a/backend/data/csvUpdater.js
+++ b/backend/data/csvUpdater.js
@@ -27,10 +27,8 @@ fs.readFile(path.join(__dirname, csvFilenameOld), function (err, fileContentsOld
 
     let output = "";
 
-    fileContentsOld = fileContentsOld.toString().replace(`'`, `"`);
-    fileContentsNew = fileContentsNew.toString().replace(`'`, `"`);
-    const dataOld = Papa.parse(fileContentsOld, { header: true }).data;
-    const dataNew = Papa.parse(fileContentsNew, { header: true }).data;
+    const dataOld = Papa.parse(fileContentsOld.toString(), { header: true }).data;
+    const dataNew = Papa.parse(fileContentsNew.toString(), { header: true }).data;
 
     const columnsOld = Object.keys(dataOld[0]);
     const columnsNew = Object.keys(dataNew[0]);


### PR DESCRIPTION
Summary
========
There was an error in how the first single quote for data being pulled into the data tables was being handled. It was converting the first single quote into a double quotation mark, instead of the normal process of converting the single quotes into two single quotes for sql string escaping.

Found this via a security alert detected in #457 

Test Plan
=======

1. Created a empty file to use to create test migration files

```shell
head -n 1 backend/data/in_demand_cips.csv > backend/data/empty.csv
```

2. Created some test update migrations

```shell
./backend/data/create_update_migrations.sh empty.csv in_demand_cips.csv indemandcips backend/migrations/sqls/upFileName.sql backend/migrations/sqls/downFileName.sql
```

3. Check that the first entry with a single quotes is now showing two single quotes in the sql statement instead of a single double quotation mark character.

```shell
grep 51.3822 ./backend/migrations/sqls/upFileName.sql
```

  Output should look like

```sql
INSERT INTO indemandcips (CIP,CIPTitle) values ('51.3822','Women''s Health Nurse/Nursing.');
```

not

```sql
INSERT INTO indemandcips (CIP,CIPTitle) values ('51.3822','Women"s Health Nurse/Nursing.');
```

4. Clean up test files

```shell
rm backend/data/empty.csv backend/migrations/sqls/upFileName.sql backend/migrations/sqls/downFileName.sql
```