### PR TITLE
fix: encode internal line feeds for data migration

### DIFF
--- a/backend/data/transform-for-migration.py
+++ b/backend/data/transform-for-migration.py
@@ -2,9 +2,9 @@ import pandas as pd
 
 def main():
     df = pd.read_csv('standardized_etpl.csv', dtype=str)
-    if any([df[col].str.contains('<LF>').any() for col in df.columns]):
+    if any([df[col].str.contains('\\\\r\\\\n').any() for col in df.columns]):
         raise 'File contains LineFeed replacement token. We need to coordinate a new replacement token'
-    df = df.replace('\n', '<LF>', regex=True)
+    df = df.replace('\r?\n', '\\\\r\\\\n', regex=True)
     df.to_csv('standardized_etpl_for_data_migration.csv', index=False, encoding='utf-8-sig', line_terminator='\r\n')
 
 


### PR DESCRIPTION
Summary
=======

Looking at examples within Credential Registry, line feeds are represented inside of string fields like description using escaped versions of CRLF (`"\r\n"`). We can use this as our line feed token to support the data migration effort.

Test Plan
=========

Ran the `transform-for-migration.py` script and checked the difference to ensure that the string literal `\r\n` was being printed where they were line feeds before.

