### PR TITLE
chore: reduce logging during feature tests

### DIFF
--- a/scripts/feature-tests.sh
+++ b/scripts/feature-tests.sh
@@ -12,7 +12,7 @@ set -e
 
 echo "starting app"
 ./scripts/build.sh
-./scripts/prod-start-local.sh &
+./scripts/prod-start-local.sh > /dev/null &
 npm --prefix=backend run start:wiremock &
 while ! echo exit | nc localhost ${WIREMOCK_PORT}; do sleep 1; done
 while ! echo exit | nc localhost ${APP_PORT}; do sleep 1; done


### PR DESCRIPTION
Summary
========

When running feature tests in CircleCI, the migration scripts running on a clean database result in around 300MBs of logged output because db-migrate logs all the data from the sql files. This makes it impractical to review failed test output on CircleCI failures.

This redirects the output of starting up the local prod server during feature tests to the null device to swallow the migration logs.

Test Plan
=======

Check the artifacts of the build-and-test job in circleci. feature-test-output.txt should now be readable / renderable in the browser and measured in KBs instead of hundreds of MBs.

Usefully, [the first run of this failed](https://app.circleci.com/pipelines/github/newjersey/d4ad/1524/workflows/e5cf6818-34f7-47bc-9c40-46ee350bc706/jobs/1595) and was able to verify that it was due to the flakey search.js feature test.