### PR TITLE
chore: use rebase for auto merges from dependabot

### DIFF
--- a/.github/workflows/dependabot-auto-approve-and-merge.yml
+++ b/.github/workflows/dependabot-auto-approve-and-merge.yml
@@ -23,7 +23,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge for minor and patch PRs
         if: ${{steps.metadata.outputs.update-type != 'version-update:semver-major'}}
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Simple change to merge with rebase instead of a merge commit when doing the auto merge from dependabot PRs.