### PR TITLE
update: check for element existence before Cypress test

### DIFF
--- a/frontend/cypress/e2e/search.cy.js
+++ b/frontend/cypress/e2e/search.cy.js
@@ -131,6 +131,7 @@ describe("Search", () => {
       cy.get("[data-testid='card']")
         .first()
         .within(() => {
+          cy.get('.result-highlight').should("exist");
           cy.get('[type="checkbox"][name="compare"]').should("exist");
           cy.get('[type="checkbox"][name="compare"]').check({ force: true });
         });

--- a/frontend/src/search-results/TrainingResultCard.tsx
+++ b/frontend/src/search-results/TrainingResultCard.tsx
@@ -134,7 +134,7 @@ export const TrainingResultCard = (props: Props): ReactElement => {
       </div>
       <div className="row">
         <div className="col-md-12">
-          {isTabletAndUp && <p>{boldHighlightedSection(props.trainingResult.highlight)}</p>}
+          {isTabletAndUp && <p className="result-highlight">{boldHighlightedSection(props.trainingResult.highlight)}</p>}
           <div className="mtxs mbz flex fac">
             {props.trainingResult.inDemand ? <InDemandTag /> : <></>}
             {props.comparisonItems && <ComparisonCheckbox />}


### PR DESCRIPTION
# Summary

When running `./scripts/feature-tests.sh` Cypress will occasionally throw an error when the searched highlight paragraph loads in slower than normal. We want to check for the existence of that paragraph before proceeding with the remainder of the test.

# Test Plan

Ran the `./scripts/feature-tests.sh` script several (many) times to verify the new check worked.