### PR TITLE
fix: handle null descriptions in search

### DIFF
--- a/backend/src/domain/training/Program.ts
+++ b/backend/src/domain/training/Program.ts
@@ -2,7 +2,7 @@ export interface Program {
   programid: string;
   cipcode: string;
   officialname: string;
-  description: string;
+  description: string | null;
   industrycredentialname: string;
   prerequisites: string;
   providerid: string;

--- a/backend/src/domain/training/findTrainingsBy.test.ts
+++ b/backend/src/domain/training/findTrainingsBy.test.ts
@@ -230,6 +230,7 @@ describe("findTrainingsBy", () => {
       peremployed2: null,
       avgquarterlywage2: null,
       onlineprogramid: null,
+      description: null,
     });
     stubDataClient.findProgramsBy.mockResolvedValue([program]);
 

--- a/backend/src/domain/training/findTrainingsBy.test.ts
+++ b/backend/src/domain/training/findTrainingsBy.test.ts
@@ -252,6 +252,7 @@ describe("findTrainingsBy", () => {
     expect(training.percentEmployed).toEqual(null);
     expect(training.averageSalary).toEqual(null);
     expect(training.online).toEqual(false);
+    expect(training.description).toEqual("");
   });
 
   it("returns null if percent employed is -99999", async () => {

--- a/backend/src/domain/training/findTrainingsBy.ts
+++ b/backend/src/domain/training/findTrainingsBy.ts
@@ -48,7 +48,7 @@ export const findTrainingsByFactory = (dataClient: DataClient): FindTrainingsBy 
               zipCode: program.zip ? formatZip(program.zip) : "",
             },
           },
-          description: stripSurroundingQuotes(stripUnicode(program.description)),
+          description: stripSurroundingQuotes(stripUnicode(program.description ?? "")),
           certifications: program.industrycredentialname,
           prerequisites: formatPrerequisites(program.prerequisites),
           calendarLength: program.calendarlengthid


### PR DESCRIPTION
Summary
=======

There are a few programs which have null descriptions within the original data. When search results included these programs, the search would error due to the backend data transformation code assuming that the description would always be a string.

Example Error:

When visiting: https://training.njcareers.org/search/trade%20worker
Got:
<img width="1358" alt="Screen Shot 2022-09-21 at 1 59 15 PM" src="https://user-images.githubusercontent.com/121035/191577239-75d9e1c3-36e9-4e14-b69a-0a318e634974.png">


This change allows for handling null program descriptions such as those cause by training 47189, and triggered by searches like `worker`.

Test Plan
=======

Ran the search `trade worker` on local environment, and confirmed that search results worked (This search fails on current prod version). 
<img width="1761" alt="Screen Shot 2022-09-21 at 1 57 49 PM" src="https://user-images.githubusercontent.com/121035/191576906-954f63e4-0a94-41f4-b728-805836955193.png">

Clicked on the entry for Hvacr and ensure the page loaded.

<img width="1488" alt="Screen Shot 2022-09-21 at 1 58 23 PM" src="https://user-images.githubusercontent.com/121035/191576997-07b53dc6-47d6-4f69-8858-4f5cfbc854b0.png">
