### PR TITLE
CTDL query filtering for credStatus Active & avaialble NJ or online

### DIFF
--- a/backend/src/domain/credentialengine/CredentialEngineFactory.ts
+++ b/backend/src/domain/credentialengine/CredentialEngineFactory.ts
@@ -11,8 +11,25 @@ export const credentialEngineFactory = ( ): GetAllCertificates => {
       url: `${gateway}`,
       method: 'POST',
       data: {
-        'Query': {
-          '@type': 'ceterms:Certificate'
+        "Query": {
+          "@type": [
+            "ceterms:Certificate",
+          ],
+          "ceterms:credentialStatusType": {
+            "ceterms:targetNode": "credentialStat:Active"
+          },
+          "ceterms:requires": {
+            "ceterms:targetAssessment": {
+              "ceterms:availableOnlineAt": "search:anyValue",
+              "ceterms:availableAt": {
+                "ceterms:addressRegion": [
+                  "New Jersey",
+                  "NJ"
+                ]
+              },
+              "search:operator": "search:orTerms"
+            }
+          }
         },
         'Skip': skip,
         'Take': take,


### PR DESCRIPTION
Changed CTDL query to filter for active certificates that are available either online or in NJ. Tested successfully both locally and in Query Helper.