### PR TITLE
NJWE-223: Implement simple password auth for Training Explorer dev site

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Dev and prod environments use a CareerOneStop account owned by NJ Office of Inno
 * `NO_COLOR`
 * `ZIPCODE_BASEURL`
 * `ZIPCODE_API_KEY`
-
+* `DEV_PASS` - password for simple password auth on non-prod environments if publicly available
 
 ### Deployment
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -6,39 +6,13 @@ import { App } from "./App";
 import { ApiClient } from "./ApiClient";
 import { createMuiTheme, ThemeProvider } from "@material-ui/core";
 import "./i18n";
-import ReactDOMServer from 'react-dom/server';
 
-const password = "foo";
+const password = process.env.DEV_PASS;
 const isCI = process.env.IS_CI;
-const isProd = process.env.IS_PROD;
+const isProd = process.env.DB_NAME === "d4adprod" ? true : false;
 
-if (isCI && !isProd) {
-  if (prompt("Enter password:") == password) {
-    const apiClient = new ApiClient();
-
-    const theme = createMuiTheme({
-      palette: {
-        primary: {
-          main: "#12263A",
-        },
-        secondary: {
-          main: "#1668B4",
-        },
-      },
-    });
-
-    ReactDOM.render(
-      <React.StrictMode>
-        <ThemeProvider theme={theme}>
-          <App client={apiClient} />
-        </ThemeProvider>
-      </React.StrictMode>,
-      document.getElementById("root")
-    );
-
-    serviceWorker.unregister();
-  }
-} else {
+// If env is running in CI and is not a prod environment, prompt for password in env var DEV_PASS
+if ((isCI && !isProd) ? prompt("Enter password:") === password : true) {
   const apiClient = new ApiClient();
 
   const theme = createMuiTheme({

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,32 +5,61 @@ import * as serviceWorker from "./serviceWorker";
 import { App } from "./App";
 import { ApiClient } from "./ApiClient";
 import { createMuiTheme, ThemeProvider } from "@material-ui/core";
-// import i18n (needs to be bundled)
 import "./i18n";
+import ReactDOMServer from 'react-dom/server';
 
-const apiClient = new ApiClient();
+const password = "foo";
+const isCI = process.env.IS_CI;
+const isProd = process.env.IS_PROD;
 
-const theme = createMuiTheme({
-  palette: {
-    primary: {
-      main: "#12263A",
+if (isCI && !isProd) {
+  if (prompt("Enter password:") == password) {
+    const apiClient = new ApiClient();
+
+    const theme = createMuiTheme({
+      palette: {
+        primary: {
+          main: "#12263A",
+        },
+        secondary: {
+          main: "#1668B4",
+        },
+      },
+    });
+
+    ReactDOM.render(
+      <React.StrictMode>
+        <ThemeProvider theme={theme}>
+          <App client={apiClient} />
+        </ThemeProvider>
+      </React.StrictMode>,
+      document.getElementById("root")
+    );
+
+    serviceWorker.unregister();
+  }
+} else {
+  const apiClient = new ApiClient();
+
+  const theme = createMuiTheme({
+    palette: {
+      primary: {
+        main: "#12263A",
+      },
+      secondary: {
+        main: "#1668B4",
+      },
     },
-    secondary: {
-      main: "#1668B4",
-    },
-  },
-});
+  });
 
-ReactDOM.render(
-  <React.StrictMode>
-    <ThemeProvider theme={theme}>
-      <App client={apiClient} />
-    </ThemeProvider>
-  </React.StrictMode>,
-  document.getElementById("root")
-);
+  ReactDOM.render(
+    <React.StrictMode>
+      <ThemeProvider theme={theme}>
+        <App client={apiClient} />
+      </ThemeProvider>
+    </React.StrictMode>,
+    document.getElementById("root")
+  );
 
-// If you want your app to work offline and load faster, you can change
-// unregister() to register() below. Note this comes with some pitfalls.
-// Learn more about service workers: https://bit.ly/CRA-PWA
-serviceWorker.unregister();
+  serviceWorker.unregister();
+}


### PR DESCRIPTION
### Summary

Implements simple password auth based on environment variable `DEV_PASS` if environment is running in CI and not in production

###  References

* https://fearless.jira.com/jira/software/projects/NJWE/boards/114?selectedIssue=NJWE-223
* 
### Test Plan

* Verify that password mechanism does not appear and site renders correctly in local dev environment
* Verify code doesn't throw test or lint errors errors
* Verify that password mechanism works in dev environment in CI
* Verify that password mechanism does not appear an site renders correctly in prod environment in CI

