### PR TITLE
V2 Minor Edits

### DIFF
--- a/backend/src/domain/training/findTrainingsBy.ts
+++ b/backend/src/domain/training/findTrainingsBy.ts
@@ -36,7 +36,7 @@ export const findTrainingsByFactory = (dataClient: DataClient): FindTrainingsBy 
     const skip = 0;
     const take = 10;
     const sort = "^search:recordCreated"
-    const programs2 = await credentialEngineAPI.getResults(query, skip, take, sort, false);
+    const programs2 = await credentialEngineAPI.getResults(query, skip, take, sort);
 
     return Promise.all(
       programs.map(async (program: Program) => {

--- a/backend/src/fence.json
+++ b/backend/src/fence.json
@@ -1,4 +1,4 @@
 {
   "tags": ["backend"],
-  "dependencies": ["knex", "express", "cors", "supertest", "axios"]
+  "dependencies": ["knex", "express", "cors", "supertest", "axios", "dotenv"]
 }


### PR DESCRIPTION
This PR removes an unused var from `findTrainingsBy.ts`. While we should consider having the option to kill API calls it is currently not implemented. I'm also not sure CE is robust enough for that type of functionality and hopefully the communication speed between our front and back ends is fast enough to not warrant one.

This PR also adds the `dotenv` package to good fences so we can use environment variables from within expressjs on GCP.