### PR TITLE
Local exceptions refinement

### DIFF
--- a/backend/src/domain/search/searchTrainings.ts
+++ b/backend/src/domain/search/searchTrainings.ts
@@ -34,7 +34,7 @@ export const searchTrainingsFactory = (
               }
             }
 
-            return {
+            const result = {
               id: training.id,
               name: training.name,
               cipCode: training.cipCode,
@@ -57,7 +57,8 @@ export const searchTrainingsFactory = (
               isWheelchairAccessible: training.isWheelchairAccessible,
               hasJobPlacementAssistance: training.hasJobPlacementAssistance,
               hasChildcareAssistance: training.hasChildcareAssistance,
-            };
+            }
+            return result;
           })
       );
     } catch (error) {

--- a/frontend/src/components/InDemandTag.tsx
+++ b/frontend/src/components/InDemandTag.tsx
@@ -15,6 +15,9 @@ export const InDemandTag = (props: Props): ReactElement => {
     if(counties.length === 0) return '';
     if(counties.length === 1) return `${counties[0]} County`;
 
+    // Handle case when there are two counties
+    if(counties.length === 2) return `${counties[0]} and ${counties[1]} Counties`;
+
     const lastCounty = counties.pop();
     return `${counties.join(', ')}, and ${lastCounty} Counties`;
   };

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -714,7 +714,7 @@ export const en = {
     onlineClassLabel: "Online Class",
     timeToComplete: "{{time}} to complete",
     inDemandTag: "In Demand",
-    inDemandCountiesTag: "In Demand in {{counties}} - tuition assistance may be available",
+    inDemandCountiesTag: "In Demand in {{counties}}",
     localWaiverTag: "Waiver for {{county}} County",
     comparisonCheckLabel: "Compare",
     comparisonCollapse: "Collapse",

--- a/frontend/src/locales/es.ts
+++ b/frontend/src/locales/es.ts
@@ -730,7 +730,7 @@ export const es = {
     onlineClassLabel: "Clase en línea",
     timeToComplete: "{{time}} para completar",
     inDemandTag: "En demanda",
-    inDemandCountiesTag: "En demanda en {{counties}} - la asistencia de matrícula puede estar disponible",
+    inDemandCountiesTag: "En demanda en {{counties}}",
     localWaiverTag: "Exención para el condado de {{county}}",
     comparisonCheckLabel: "Comparar",
     comparisonCollapse: "Colapsar",

--- a/frontend/src/search-results/TrainingResultCard.tsx
+++ b/frontend/src/search-results/TrainingResultCard.tsx
@@ -141,10 +141,14 @@ export const TrainingResultCard = (props: Props): ReactElement => {
           )}
           <div className="mtxs mbz flex fac">
             {props.trainingResult.inDemand ? <InDemandTag /> : <></>}
-            {(!props.trainingResult.inDemand && props.trainingResult.localExceptionCounty)
+            {
+              (
+              !props.trainingResult.inDemand &&
+              props.trainingResult.localExceptionCounty &&
+              (props.trainingResult.localExceptionCounty.includes(removeCountyFromEnd(props.trainingResult.county)) || props.trainingResult.online)
                 ? <InDemandTag counties={props.trainingResult.localExceptionCounty} />
                 : <></>
-            }
+            )}
             {props.comparisonItems && <ComparisonCheckbox />}
           </div>
         </div>
@@ -152,3 +156,14 @@ export const TrainingResultCard = (props: Props): ReactElement => {
     </div>
   );
 };
+
+function removeCountyFromEnd(str: string) {
+  const trimmedStr = str.trim();
+  const countyIndex = trimmedStr.lastIndexOf("County");
+
+  if (countyIndex !== -1 && countyIndex === trimmedStr.length - 6) {
+    return trimmedStr.substring(0, countyIndex).trim();
+  }
+
+  return trimmedStr;
+}

--- a/frontend/src/search-results/TrainingResultCard.tsx
+++ b/frontend/src/search-results/TrainingResultCard.tsx
@@ -141,7 +141,10 @@ export const TrainingResultCard = (props: Props): ReactElement => {
           )}
           <div className="mtxs mbz flex fac">
             {props.trainingResult.inDemand ? <InDemandTag /> : <></>}
-            {props.trainingResult.localExceptionCounty ? <InDemandTag counties={props.trainingResult.localExceptionCounty} /> : <></>}
+            {(!props.trainingResult.inDemand && props.trainingResult.localExceptionCounty)
+                ? <InDemandTag counties={props.trainingResult.localExceptionCounty} />
+                : <></>
+            }
             {props.comparisonItems && <ComparisonCheckbox />}
           </div>
         </div>


### PR DESCRIPTION
From @andrealuft:

`Woohoo! way to go Chelsea getting those by county in demand labels on there!
3 things:

I think we should remove the "tuition assistance may be available" for now. (I think it does make the tags too long and whatever we choose to do should also be on the non county specific tags).

The county specific tags should only be on trainings located in the counties where that occupation is in-demand or online trainings.

A lot of trainings are getting two regular in-demand tags or one reg in-demand tag and one country specific tag....`