### PR TITLE
Updated the BetaBanner component tests to correctly select the parent…

### DIFF
--- a/frontend/src/components/BetaBanner.test.tsx
+++ b/frontend/src/components/BetaBanner.test.tsx
@@ -5,13 +5,13 @@ import { BetaBanner } from "./BetaBanner";
 describe("<BetaBanner />", () => {
   it("accepts a prop for removing the header margin", () => {
     const subject = render(<BetaBanner noHeader={true} />);
-    const banner = subject.getByText("feedback", { exact: false });
+    const banner = subject.getByText("Share your feedback!", { exact: false }).parentElement;
     expect(banner).toHaveClass("no-header-margin");
   });
 
   it("uses default margin if no header prop passed", () => {
     const subject = render(<BetaBanner />);
-    const banner = subject.getByText("feedback", { exact: false });
+    const banner = subject.getByText("Share your feedback!", { exact: false }).parentElement;
     expect(banner).not.toHaveClass("no-header-margin");
   });
 });


### PR DESCRIPTION
… div of the anchor tag when checking for the presence of the 'no-header-margin' class. This resolves the test failure where the class was being incorrectly checked on the anchor tag itself.