### PR TITLE
feat: Enable sub-URL redirection in app.yaml

### DIFF
--- a/backend/app.yaml.sh
+++ b/backend/app.yaml.sh
@@ -21,4 +21,12 @@ env_variables:
   DELIVERY_API: \"$DELIVERY_API\"
   SENTRY_DSN: \"$SENTRY_DSN\"
   NODE_OPTIONS: --max_old_space_size=4096
+handlers:
+- url: training\.njcareers\.org/.*
+  script: auto
+  secure: always
+  redirect_http_response_code: 301
+  redirect_matcher:
+    regex: (.*)
+    location: https://mycareer.nj.gov/training\1
 """


### PR DESCRIPTION
Updated the app.yaml configuration to include a domain redirection rule that carries over sub-URLs for 'training.njcareers.org'. Now, requests like 'https://training.njcareers.org/training/37332' will correctly redirect to 'https://mycareer.nj.gov/training/37332' while preserving the sub-URL path.