### PR TITLE
1293 - Make homepage tool buttons focused on tab

### DIFF
--- a/frontend/src/styles/components/_introBlocks.scss
+++ b/frontend/src/styles/components/_introBlocks.scss
@@ -143,6 +143,12 @@
             background-color: $info-light;
           }
         }
+
+        &:focus {
+          &:focus {
+            outline: 0.25rem solid $navy;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
No focus:
![image](https://github.com/newjersey/d4ad/assets/44708048/b7c04789-7269-468a-ad09-f239cc2494ea)

Focus:
![image](https://github.com/newjersey/d4ad/assets/44708048/99bb460e-367b-4e1c-86c9-7cce9517a60b)
