### PR TITLE
[NJWE-1414] Fix Google Analytics Tracking for Client-Side Navigation  Description

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -69,7 +69,7 @@ Sentry.init({
 declare const window: any;
 const GA_TRACKING_ID = "G-THV625FWWB";
 globalHistory.listen(({ location }) => {
-  if (typeof window.gtag === "function") {
+  if (location.href.startsWith("https://mycareer.nj") && typeof window.gtag === "function") {
     window.gtag("config", GA_TRACKING_ID, { page_path: location.pathname });
   }
 });


### PR DESCRIPTION
## Overview
This Pull Request addresses a critical issue in the New Jersey Career Central application where Google Analytics (GA) was erroneously tracking page views in all environments, including localhost, user research, and development environments. The proposed fix ensures GA tracking is exclusive to the production environment, specifically for URLs starting with "https://mycareer.nj".

## Changes
- Implemented a URL check in the global history listener within the main React component.
- GA tracking now exclusively tracks page views for "https://mycareer.nj", effectively excluding localhost, dev, and user research environments.

## Purpose
The main objective of this PR is to enhance the integrity and relevance of our GA data by:
  - Excluding tracking data from non-production environments like localhost, user research sessions, and development setups.
  - Focusing on user interactions that occur in the real-world production environment, providing a true reflection of user behavior and application usage.

## Testing Procedure
1. Verify that GA no longer tracks page views in development, localhost, and user research environments.
2. In the production environment, confirm that GA only tracks pages with URLs starting with "https://mycareer.nj".
3. Run updated unit tests to ensure compliance with the new tracking logic.

## Ticket
Resolves [NJWE-1414](https://fearless.jira.com/browse/NJWE-1414?atlOrigin=eyJpIjoiZThhMDg5MDk0OTIzNDAzNGE1OGJkM2Y4NTI2YTUwMDciLCJwIjoiaiJ9)

## Additional Notes
This change is pivotal for maintaining the quality of our analytics. It ensures that the data we collect and analyze is strictly from our target audience in the intended environment, thus facilitating more accurate and actionable insights.

Please review the changes and provide your feedback.