### PR TITLE
1433: <title> element for TE advanced search page is `Search results for "undefined"`

### DIFF
--- a/frontend/src/search-results/SearchResultsPage.tsx
+++ b/frontend/src/search-results/SearchResultsPage.tsx
@@ -192,7 +192,7 @@ export const SearchResultsPage = (props: Props): ReactElement<Props> => {
       noFooter
       client={props.client}
       seo={{
-        title: `Search results for "${props.searchQuery}" | New Jersey Career Central`,
+        title: `Advanced Search | Training Explorer | New Jersey Career Central`,
         url: props.location?.pathname,
       }}
     >


### PR DESCRIPTION
Resolves [1433](https://fearless.jira.com/jira/software/projects/NJWE/boards/114/backlog?assignee=712020%3A7f5e8498-eeba-4ef6-b44a-4185883e207e&selectedIssue=NJWE-1433)

Currently, the Advanced Search page for Training Explorer shows having a <title> element of Search results for "undefined". Changed to Advanced Search | Training Explorer | New Jersey Career Central for the sake of UX and tracking.