### PR TITLE
Fix: Add Missing Babel Plugin to devDependencies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,6 +47,7 @@
         "winston-cloudwatch": "^6.2.0"
       },
       "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@types/dompurify": "^3.0.5",
         "@types/markdown-it": "^13.0.6",
         "@types/node": "^16.18.80",
@@ -1427,9 +1428,17 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -2673,6 +2682,17 @@
         "core-js-compat": "^3.31.0",
         "semver": "^6.3.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "engines": {
         "node": ">=6.9.0"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,6 +79,7 @@
   },
   "proxy": "http://localhost:8080",
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@types/dompurify": "^3.0.5",
     "@types/markdown-it": "^13.0.6",
     "@types/node": "^16.18.80",


### PR DESCRIPTION
# Summary
This PR addresses a build warning related to an implicit dependency on `@babel/plugin-proposal-private-property-in-object` by explicitly adding it to our project's `devDependencies`. This ensures our build process is stable and prevents potential future issues that could arise from this missing dependency.

# Background
During the build process, a warning was encountered indicating that `babel-preset-react-app` is implicitly depending on `@babel/plugin-proposal-private-property-in-object` without declaring it. Given that `babel-preset-react-app` is part of the no-longer-maintained `create-react-app`, and this dependency issue is unlikely to be resolved in that project, we need to manually add the missing plugin to our `devDependencies`.

# Changes
- Added `@babel/plugin-proposal-private-property-in-object` to `devDependencies` in `package.json`.

# Rationale
Adding the plugin directly to our project's `devDependencies`:
- Eliminates the build warning about the implicit dependency.
- Secures our build process against potential future failures related to this dependency.
- Is a recommended workaround for the issue as the original package (`babel-preset-react-app`) is not actively maintained.

# Testing
- Ensure that the build process completes without the previously mentioned warning.
- Run a full build and test cycle to confirm that adding this dependency does not affect the build or runtime behavior of our application.

# Impact
- This change has no expected impact on the application's functionality or performance.
- Developers need to run `npm install` after pulling these changes to update their local `node_modules`.
