### PR TITLE
1583: Active FAQ state on page load

### DIFF
--- a/frontend/src/components/DropNav.tsx
+++ b/frontend/src/components/DropNav.tsx
@@ -1,12 +1,6 @@
 import { useEffect, useState } from "react";
 import { DropGroup } from "./modules/DropGroup";
-import { FaqItem } from "../types/contentful";
-
-interface TopicProps {
-  sys: { id: string };
-  topic: string;
-  itemsCollection: { items: FaqItem[] };
-}
+import { FaqTopic } from "../types/contentful";
 
 interface DropNavProps {
   className?: string;
@@ -15,14 +9,14 @@ interface DropNavProps {
     sys: { id: string };
     title: string;
     topics: {
-      items: TopicProps[];
+      items: FaqTopic[];
     };
   }[];
-  onChange?: (selected: TopicProps) => void;
+  onChange?: (selected: FaqTopic) => void;
 }
 
 const DropNav = ({ className, elementId, onChange, items }: DropNavProps) => {
-  const [activeTopic, setActiveTopic] = useState<TopicProps>();
+  const [activeTopic, setActiveTopic] = useState<FaqTopic>();
 
   useEffect(() => {
     if (onChange && activeTopic) {

--- a/frontend/src/components/modules/DropGroup.tsx
+++ b/frontend/src/components/modules/DropGroup.tsx
@@ -30,6 +30,27 @@ const DropGroup = ({ activeItem, className, onChange, sys, title, topics }: Drop
     if (onChange && activeTopic) {
       onChange(activeTopic);
     }
+
+    if (!activeTopic) {
+      const urlParams = window.location.hash;
+      const searchTopic = urlParams.replace("#", "");
+
+      if (searchTopic) {
+        const searchedTopic = topics.items.find((topic) => slugify(topic.topic) === searchTopic);
+
+        if (searchedTopic) {
+          setActiveTopic(searchedTopic);
+          setOpen(true)
+          const contentBlock = document.getElementById(`list-${sys?.id}`);
+
+          if (contentBlock) {
+            const height = contentBlock?.scrollHeight;
+            contentBlock.style.height = `${height}px`;
+          }
+        }
+      }
+    }
+
     if (activeTopic) {
       setOpen(true);
     }

--- a/frontend/src/components/modules/DropGroup.tsx
+++ b/frontend/src/components/modules/DropGroup.tsx
@@ -1,5 +1,6 @@
 import { CaretRight } from "@phosphor-icons/react";
 import { useEffect, useState } from "react";
+import { useLocation } from "@reach/router";
 import { FaqTopic } from "../../types/contentful";
 import { slugify } from "../../utils/slugify";
 
@@ -25,7 +26,10 @@ const toggleOpen = (isOpen: boolean, contentId: string): void => {
 const DropGroup = ({ activeItem, className, onChange, sys, title, topics }: DropGroupProps) => {
   const [open, setOpen] = useState<boolean>(false);
   const [activeTopic, setActiveTopic] = useState<FaqTopic>();
+  // const [location, setLocation] = useState<string>("");
+  const location = useLocation();
 
+  // If activeTopic is set, open the accordion
   useEffect(() => {
     if (onChange && activeTopic) {
       onChange(activeTopic);
@@ -33,6 +37,7 @@ const DropGroup = ({ activeItem, className, onChange, sys, title, topics }: Drop
 
     if (!activeTopic) {
       const urlParams = window.location.hash;
+      // setLocation(urlParams);
       const searchTopic = urlParams.replace("#", "");
 
       if (searchTopic) {
@@ -48,6 +53,19 @@ const DropGroup = ({ activeItem, className, onChange, sys, title, topics }: Drop
             contentBlock.style.height = `${height}px`;
           }
         }
+      } else {
+        const searchedTopic = topics.items.find((topic) => slugify(topic.topic) === 'training');
+        
+        if (searchedTopic) {
+          setActiveTopic(searchedTopic);
+          setOpen(true)
+          const contentBlock = document.getElementById(`list-${sys?.id}`);
+  
+          if (contentBlock) {
+            const height = contentBlock?.scrollHeight;
+            contentBlock.style.height = `${height}px`;
+          }
+        }
       }
     }
 
@@ -55,6 +73,30 @@ const DropGroup = ({ activeItem, className, onChange, sys, title, topics }: Drop
       setOpen(true);
     }
   }, [activeTopic]);
+
+  // If hash changes, update the activeTopic
+  useEffect(() => {
+    if (activeTopic) {
+      if (location.hash !== `#${slugify(activeTopic.topic)}`) {
+        const searchTopic = location.hash.replace("#", "");
+        
+        if (searchTopic) {
+          const searchedTopic = topics.items.find((topic) => slugify(topic.topic) === searchTopic);
+        
+          if (searchedTopic) {
+            setActiveTopic(searchedTopic);
+            setOpen(true)
+            const contentBlock = document.getElementById(`list-${sys?.id}`);
+    
+            if (contentBlock) {
+              const height = contentBlock?.scrollHeight;
+              contentBlock.style.height = `${height}px`;
+            }
+          }
+        }
+      }
+    }
+  }, [location]);
 
   return (
     <li

--- a/frontend/src/components/modules/DropGroup.tsx
+++ b/frontend/src/components/modules/DropGroup.tsx
@@ -1,23 +1,17 @@
 import { CaretRight } from "@phosphor-icons/react";
 import { useEffect, useState } from "react";
-import { FaqItem } from "../../types/contentful";
+import { FaqTopic } from "../../types/contentful";
 import { slugify } from "../../utils/slugify";
-
-interface TopicProps {
-  sys: { id: string };
-  topic: string;
-  itemsCollection: { items: FaqItem[] };
-}
 
 interface DropGroupProps {
   sys: { id: string };
   title: string;
   topics: {
-    items: TopicProps[];
+    items: FaqTopic[];
   };
-  activeItem?: TopicProps;
+  activeItem?: FaqTopic;
   className?: string;
-  onChange?: (selected: TopicProps) => void;
+  onChange?: (selected: FaqTopic) => void;
 }
 
 const toggleOpen = (isOpen: boolean, contentId: string): void => {
@@ -30,7 +24,7 @@ const toggleOpen = (isOpen: boolean, contentId: string): void => {
 
 const DropGroup = ({ activeItem, className, onChange, sys, title, topics }: DropGroupProps) => {
   const [open, setOpen] = useState<boolean>(false);
-  const [activeTopic, setActiveTopic] = useState<TopicProps>();
+  const [activeTopic, setActiveTopic] = useState<FaqTopic>();
 
   useEffect(() => {
     if (onChange && activeTopic) {

--- a/frontend/src/components/modules/DropGroup.tsx
+++ b/frontend/src/components/modules/DropGroup.tsx
@@ -24,10 +24,9 @@ const toggleOpen = (isOpen: boolean, contentId: string): void => {
 };
 
 const DropGroup = ({ activeItem, className, onChange, sys, title, topics }: DropGroupProps) => {
+  const location = useLocation();
   const [open, setOpen] = useState<boolean>(false);
   const [activeTopic, setActiveTopic] = useState<FaqTopic>();
-  // const [location, setLocation] = useState<string>("");
-  const location = useLocation();
 
   // If activeTopic is set, open the accordion
   useEffect(() => {
@@ -37,7 +36,6 @@ const DropGroup = ({ activeItem, className, onChange, sys, title, topics }: Drop
 
     if (!activeTopic) {
       const urlParams = window.location.hash;
-      // setLocation(urlParams);
       const searchTopic = urlParams.replace("#", "");
 
       if (searchTopic) {

--- a/frontend/src/types/contentful.ts
+++ b/frontend/src/types/contentful.ts
@@ -150,13 +150,19 @@ export interface FaqItem {
 }
 
 export interface FaqTopic {
-  sys?: {
+  sys: {
     id: string;
   };
   topic: string;
   itemsCollection: {
     items: FaqItem[];
   };
+}
+
+interface TopicProps {
+  sys: { id: string };
+  topic: string;
+  itemsCollection: { items: FaqItem[] };
 }
 
 export interface LinkObjectProps {

--- a/frontend/src/types/contentful.ts
+++ b/frontend/src/types/contentful.ts
@@ -159,12 +159,6 @@ export interface FaqTopic {
   };
 }
 
-interface TopicProps {
-  sys: { id: string };
-  topic: string;
-  itemsCollection: { items: FaqItem[] };
-}
-
 export interface LinkObjectProps {
   sys?: {
     id: string;


### PR DESCRIPTION
Resolves [1583](https://fearless.jira.com/jira/software/projects/NJWE/boards/114?assignee=712020%3A7f5e8498-eeba-4ef6-b44a-4185883e207e&selectedIssue=NJWE-1583)

##The Issue:
The active Faq section isn’t highlighted when going to an faq section direct in a url like https://mycareer.nj.gov/faq#etpl-program-general-information

**Expected**
![image](https://github.com/newjersey/d4ad/assets/44708048/e170b73f-db05-4a4e-a61d-4ce2040adf75)

**Actual**
![image](https://github.com/newjersey/d4ad/assets/44708048/8fdb3bc2-87a5-4c5d-bd36-fad81d626f77)

##Notes:
In addition to fixing the first bug, I also noted that if you were on the FAQ page and only changed the URL, the site would not open the correct accordion.

##Ready to Merge When:
- [ ] All tests pass
- [ ] At least one code review
- [ ] At least one practical review
    - [ ] Check when inputting url with specified hash it opens the correct accordion and highlights correct buttons
    - [ ] Check when changing url it opens the correct accordion and highlights correct buttons
    - [ ] If no hash is given, it opens the first button/topic (`#training`)