### PR TITLE
1576 - Allow TE search of SOC code without dash

### DIFF
--- a/frontend/src/search-results/SearchResultsPage.tsx
+++ b/frontend/src/search-results/SearchResultsPage.tsx
@@ -18,6 +18,7 @@ import { logEvent } from "../analytics";
 import { Layout } from "../components/Layout";
 import { usePageTitle } from "../utils/usePageTitle";
 import { ArrowLeft } from "@phosphor-icons/react";
+import { checkValidSocCode } from "../utils/checkValidCodes";
 
 interface Props extends RouteComponentProps {
   client: Client;
@@ -93,7 +94,9 @@ export const SearchResultsPage = (props: Props): ReactElement<Props> => {
   };
 
   useEffect(() => {
-    const queryToSearch = searchQuery ? searchQuery : "";
+    let queryToSearch = searchQuery ? searchQuery : "";
+    
+    queryToSearch = checkValidSocCode(queryToSearch);
 
     props.client.getTrainingsByQuery(queryToSearch, {
       onSuccess: (data: TrainingResult[]) => {

--- a/frontend/src/utils/checkValidCodes.test.ts
+++ b/frontend/src/utils/checkValidCodes.test.ts
@@ -1,0 +1,21 @@
+import { checkValidSocCode } from "./checkValidCodes";
+
+describe("checkValidSocCode", () => {
+  it("returns the value if it does not have six digits", () => {
+    const value = "12345";
+    const result = checkValidSocCode(value);
+    expect(result).toEqual(value);
+  });
+
+  it("returns the formatted value if it has six digits and the prefix is valid", () => {
+    const value = "135791";
+    const result = checkValidSocCode(value);
+    expect(result).toEqual("13-5791");
+  });
+
+  it("returns the value if it has six digits but the prefix is invalid", () => {
+    const value = "999999";
+    const result = checkValidSocCode(value);
+    expect(result).toEqual(value);
+  });
+});

--- a/frontend/src/utils/checkValidCodes.ts
+++ b/frontend/src/utils/checkValidCodes.ts
@@ -1,0 +1,21 @@
+const socPrefixes = ['00', '11', '13', '15', '17', '19', '21', '23', '25', '27', '29', '31', '33', '35', '37', '39', '41', '43', '45', '47', '49', '51', '53']
+
+// const cipPrefixes = ['01', '03', '04', '05', '09', '10', '11', '12', '13', '14', '15', '16', '19', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '60', '61']
+
+const hasSixDigits = (value: string) => {
+  const parsedValue = value.replace(/[^0-9]/g, '');
+  return parsedValue.length === 6;
+}
+
+export const checkValidSocCode = (value: string) => {
+  if (!hasSixDigits(value)) return value;
+
+  const firstTwoDigits = value.slice(0, 2);
+  const restOfDigits = value.slice(2);
+
+  if (socPrefixes.includes(firstTwoDigits)) {
+    return `${firstTwoDigits}-${restOfDigits}`;
+  }
+
+  return value;
+};


### PR DESCRIPTION
**Problem:** If a user wanted to search via SOC code, they could so long as the `-` was included in the number (i.e. 29-0342). If they input a number without the `-`, it won't work.

**Solution:** Put validator on frontend that returns a SOC with hyphen, otherwise returns original search.

**This ticket is done when:**
- [ ] Review by dev
- [ ] Review by design
- [ ] Confirms that _valid_ SOC codes return search with or without hyphen.

**Notes:**
Due to us adopting Credential Engine and probably undergoing a back-end overhaul there was no need to go into partial searches. There will also be an issue with similar CIP codes (currently not able to search for).