### PR TITLE
Automate Dependabot PR approval and merge for minor/patch updates

### DIFF
--- a/.github/workflows/dependabot-auto-approve-and-merge.yml
+++ b/.github/workflows/dependabot-auto-approve-and-merge.yml
@@ -1,29 +1,37 @@
-name: Dependabot approve and merge
-on: pull_request
+name: Dependabot Approve and Merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
-  dependabot:
+  auto-approve-and-merge:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: github.actor == 'dependabot[bot]'
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v1.1.1
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Approve minor and patch PRs
-        if: ${{steps.metadata.outputs.update-type != 'version-update:semver-major'}}
-        run: gh pr review --approve "$PR_URL"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve PR
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: |
+          gh pr review --approve "${{ github.event.pull_request.html_url }}"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Enable auto-merge for minor and patch PRs
-        if: ${{steps.metadata.outputs.update-type != 'version-update:semver-major'}}
-        run: gh pr merge --auto --rebase "$PR_URL"
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: |
+          gh pr merge --auto --rebase "${{ github.event.pull_request.html_url }}"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit refines the GitHub Actions workflow to automate the approval and merging process for Dependabot-generated pull requests targeting minor and patch updates. Key modifications include:
- Adjusting the trigger event to pull_request_target, ensuring the workflow runs securely in the context of the base repository.
- Incorporating a conditional step to approve only minor and patch updates, determined by the fetched PR metadata.
- Utilizing the GitHub CLI (`gh`) to execute approval and auto-merge commands seamlessly.

These changes streamline the integration of non-major version updates, enhancing the efficiency of dependency management while maintaining code stability and security.